### PR TITLE
Added test-only NullHtmlWriter and Deferred

### DIFF
--- a/benchmark/src/commonMain/kotlin/dev/scottpierce/html/benchmark/KotlinHtml.kt
+++ b/benchmark/src/commonMain/kotlin/dev/scottpierce/html/benchmark/KotlinHtml.kt
@@ -1,11 +1,11 @@
 package dev.scottpierce.html.benchmark
 
 import dev.scottpierce.html.element.*
+import dev.scottpierce.html.write.HtmlWriter
 import dev.scottpierce.html.write.StringBuilderHtmlWriter
-import dev.scottpierce.html.write.WriteOptions
 
-fun kotlinHtmlPage(): String {
-    val writer = StringBuilderHtmlWriter(options = WriteOptions.minified).apply {
+fun kotlinHtmlPage(htmlWriter: HtmlWriter=StringBuilderHtmlWriter()): String {
+    val writer = htmlWriter.apply {
         html {
             head {
                 metaCharsetUtf8()

--- a/benchmark/src/commonMain/kotlin/dev/scottpierce/html/benchmark/SimpleBenchmark.kt
+++ b/benchmark/src/commonMain/kotlin/dev/scottpierce/html/benchmark/SimpleBenchmark.kt
@@ -1,5 +1,10 @@
 package dev.scottpierce.html.benchmark
 
+import dev.scottpierce.html.write.*
+
+val innerLoopSize = 20_000
+
+
 object SimpleBenchmark {
     fun run(print: Boolean) {
         val results = mutableListOf<Long>()
@@ -12,14 +17,13 @@ object SimpleBenchmark {
             val startTime = Platform.currentTime
 
             // Build a simple website 20,000 times
-            for (i in 0 until 20_000) {
-                val result = kotlinHtmlPage()
+            for (i in 0 until innerLoopSize) {
+                val result = kotlinHtmlPage(StringBuilderHtmlWriter(options = WriteOptions.minified))
                 count += result.length
             }
 
             val benchmarkTime = Platform.currentTime - startTime
             results += benchmarkTime
-
             if (print) {
                 println("Iteration Took $benchmarkTime millis. Count: $count")
             }
@@ -30,5 +34,107 @@ object SimpleBenchmark {
         if (print) {
             println("Benchmark Completed. Benchmark Total Millis: $benchmarkTotalMillis, Average iteration was ${results.average()} millis")
         }
+    }
+}
+
+/**
+ * simplest possible measurement of the construction costs where the compiler can short-circuit everything except the test itself
+ */
+object NullBenchmark {
+    fun run(print: Boolean) {
+        println("Null benchmark start")
+        val results = mutableListOf<Long>()
+
+        val benchmarkStart = Platform.currentTime
+
+        repeat(50) {
+            var count = 0
+
+            val startTime = Platform.currentTime
+
+            // Build a simple website 20,000 times
+            for (i in 0 until innerLoopSize) count += kotlinHtmlPage(NullHtmlWriter(options = WriteOptions.minified)).length
+
+            val benchmarkTime = Platform.currentTime - startTime
+            results += benchmarkTime
+
+            if (print) println("Iteration Took $benchmarkTime millis. Count: $count")
+        }
+
+        val benchmarkTotalMillis = Platform.currentTime - benchmarkStart
+
+        if (print) println("Null Benchmark Completed. Benchmark Total Millis: $benchmarkTotalMillis, Average iteration was ${results.average()} millis")
+    }
+}
+
+/**
+ * simple benchmark to isolate the construction costs and "IO" costs discretely and possibly
+ * increase inner-loop locality of reference
+ */
+object DeferredBenchmark {
+    fun run(print: Boolean) {
+        println("DeferredBenchmark start")
+        val results = mutableListOf<Long>()
+
+        val benchmarkStart = Platform.currentTime
+        repeat(50) {
+            val creationcostresults = Array<Long>(innerLoopSize, { 0 })
+            val reifycostresults = Array<Long>(innerLoopSize, { 0 })
+            var count = 0
+//            val writers: MutableList<DeferredHtmlWriter> = mutableListOf()
+
+            val startTime = Platform.currentTime
+
+            // Build a simple website 20,000 times
+            (0 until innerLoopSize).forEach { i ->
+                val creation = Platform.currentTime
+
+                //we really want to defer these all until the last timer evaluation but linux_x64 clearly runs up a
+                // huge heap cost for this test if we store 20k of these in a list
+                val htmlWriter =
+                    DeferredHtmlWriter(StringBuilderHtmlWriter(options = WriteOptions.minified))
+                val result = kotlinHtmlPage(htmlWriter)
+
+                val creationDone = Platform.currentTime
+
+                htmlWriter.reify()
+
+                reifycostresults[i] = Platform.currentTime - creationDone
+                creationcostresults[i] = creationDone - creation
+
+                count += result.length
+            }
+
+            var benchmarkTime = Platform.currentTime - startTime
+            results += benchmarkTime
+
+//            writers.forEach { it.reify() }
+            if (print) {
+                val c: Double = creationcostresults.sum().toDouble()
+                val r: Double = reifycostresults.sum().toDouble()
+                if (print) println("Iteration Took $benchmarkTime millis. Count: $count; Creation $c; Reify $r; r/c = ${r / c}")
+            }
+
+        }
+
+        val finalTime = Platform.currentTime
+        val benchmarkTotalMillis = finalTime - benchmarkStart
+        if (print) {
+            val average = results.average()
+            println("Deferred Benchmark Total Millis: $benchmarkTotalMillis, Average iteration was $average millis ")
+//            val avgcreation = creationcostresults.average()
+//            val avgreify = reifycostresults.average()
+//            println("creation/reaify split: create: ${avgcreation} reify: ${reifycostresults} ratio ${avgreify / avgcreation} = r/c   ")
+        }
+
+
+    }
+}
+
+object ThreeBenchmarks {
+    fun run(print: Boolean) {
+        SimpleBenchmark.run(print)
+        DeferredBenchmark.run(print)
+        NullBenchmark.run(print)
     }
 }

--- a/benchmark/src/commonMain/kotlin/dev/scottpierce/html/benchmark/SimpleBenchmark.kt
+++ b/benchmark/src/commonMain/kotlin/dev/scottpierce/html/benchmark/SimpleBenchmark.kt
@@ -7,6 +7,7 @@ val innerLoopSize = 20_000
 
 object SimpleBenchmark {
     fun run(print: Boolean) {
+        println("start simple benchmark")
         val results = mutableListOf<Long>()
 
         val benchmarkStart = Platform.currentTime

--- a/benchmark/src/jvmMain/kotlin/dev/scottpierce/html/benchmark/ThreadedBenchmark.kt
+++ b/benchmark/src/jvmMain/kotlin/dev/scottpierce/html/benchmark/ThreadedBenchmark.kt
@@ -9,14 +9,14 @@ object ThreadedBenchmark {
     fun runBenchmark() {
         // Warmup
         println("Running a warm-up pass for kotlin-html")
-        benchmark(false) { kotlinHtmlPage().length }
+        benchmark(false) { kotlinHtmlPage( ).length }
 
         System.gc()
         Thread.sleep(5000)
 
         // Run Benchmark
         println("Running Benchmark for kotlin-html")
-        benchmark(true) { kotlinHtmlPage().length }
+        benchmark(true) { kotlinHtmlPage( ).length }
 
         System.gc()
         Thread.sleep(5000)

--- a/benchmark/src/linuxX64Main/kotlin/BenchmarkNativeMain.kt
+++ b/benchmark/src/linuxX64Main/kotlin/BenchmarkNativeMain.kt
@@ -1,5 +1,6 @@
 import dev.scottpierce.html.benchmark.SimpleBenchmark
+import dev.scottpierce.html.benchmark.ThreeBenchmarks
 
 fun main() {
-    SimpleBenchmark.run(true)
+    ThreeBenchmarks.run(true)
 }

--- a/kotlin-html/src/commonMain/kotlin/dev/scottpierce/html/write/HtmlWriter.kt
+++ b/kotlin-html/src/commonMain/kotlin/dev/scottpierce/html/write/HtmlWriter.kt
@@ -9,7 +9,7 @@ interface HtmlWriter {
     val isEmpty: Boolean
 
     fun write(c: Char): HtmlWriter
-    fun write(code: CharSequence): HtmlWriter
+    fun write(code: String): HtmlWriter
     fun newLine(): HtmlWriter
     fun indent()
     fun deindent()
@@ -49,13 +49,13 @@ abstract class AbstractHtmlWriter(final override val options: WriteOptions) : Ht
         writeChar(c)
     }
 
-    final override fun write(code: CharSequence) = apply {
+    final override fun write(code: String) = apply {
         isEmpty = false
         writeCharSequence(code)
     }
 
     abstract fun writeChar(c: Char)
-    abstract fun writeCharSequence(code: CharSequence)
+    abstract fun writeCharSequence(code: String)
 }
 
 class StringBuilderHtmlWriter(
@@ -68,7 +68,7 @@ class StringBuilderHtmlWriter(
         sb.append(c)
     }
 
-    override fun writeCharSequence(code: CharSequence) {
+    override fun writeCharSequence(code: String) {
         sb.append(code)
     }
 
@@ -90,7 +90,7 @@ class NullHtmlWriter(
 ) : AbstractHtmlWriter(options) {
 
     override fun writeChar(c: Char) {}
-    override fun writeCharSequence(code: CharSequence) {}
+    override fun writeCharSequence(code: String) {}
     override fun toString() = ""
 }
 
@@ -105,7 +105,7 @@ class DeferredHtmlWriter(
 
     override fun write(c: Char): HtmlWriter = apply { deferredTask.add { delegate.write(c) } }
 
-    override fun write(code: CharSequence): HtmlWriter = apply {
+    override fun write(code: String): HtmlWriter = apply {
         deferredTask.add { delegate.write(code) }
     }
 


### PR DESCRIPTION
tested a few things with the linux native performance.  deferred writer just wraps all writer ops into a delegate lambda, unconcerned with the eventual output toString() (it's likely rubbish in all cases where the delegate is not writing to a sequential sink)

no commentary on OO encapuslation here, i appear to have exposed some privates in the name of inline methods, and that completely hammered performance.  did not make them private again.  unintentional commit of the java benchmark.

in summary:  the pre-write overhead seems high for the purposes of signalling indents, pointers to constant strings, and concatenating them.

the post-write string appenders don't appear to cost as much benchmark time as the creation event of wrapping them in the lambda.  this surprises me because compilers can see where and when lambdas are created and work backwards,  but is not expected to do as well at optimizing the actual call-site of a lambda in a perfect smalltalk world.    for hotspot this is probably a minor warm-up blip on the timeline with no consequence.  likewise, we can't say that this native compilation is doing -O6 -lto on my setup, but finding a reference to those llvm switches would make an interesting followup  



for native:
---
baseline SimpleBenchmark
Iteration Took 3925 millis. Count: 154340000
Benchmark Completed. Benchmark Total Millis: 207804, Average iteration was 4155.96 millis

DeferredBenchmark:
Iteration Took 29691 millis. Count: 1060000; Creation 19299.0; Reify 10376.0; r/c = 0.53

NullBenchmark: 795 millis